### PR TITLE
Use serilog namespace to avoid excessive namespace using statements

### DIFF
--- a/src/Serilog.Enrichers.ClassName/ClassNameEnricher.cs
+++ b/src/Serilog.Enrichers.ClassName/ClassNameEnricher.cs
@@ -1,21 +1,20 @@
 ﻿using Serilog.Core;
 using Serilog.Events;
 
-namespace Serilog.Enrichers.ClassName
+namespace Serilog;
+
+public class ClassNameEnricher : ILogEventEnricher
 {
-    public class ClassNameEnricher : ILogEventEnricher
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {
-        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        _ = logEvent ?? throw new ArgumentNullException(nameof(logEvent));
+        _ = propertyFactory ?? throw new ArgumentNullException(nameof(propertyFactory));
+
+        if (logEvent.Properties.TryGetValue("SourceContext", out var value))
         {
-            _ = logEvent ?? throw new ArgumentNullException(nameof(logEvent));
-            _ = propertyFactory ?? throw new ArgumentNullException(nameof(propertyFactory));
+            var source = value.ToString("l", null).Split('.').Last();
 
-            if (logEvent.Properties.TryGetValue("SourceContext", out var value))
-            {
-                var source = value.ToString("l", null).Split('.').Last();
-
-                logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("ClassName", source));
-            }
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("ClassName", source));
         }
     }
 }

--- a/src/Serilog.Enrichers.ClassName/LoggingExtensions.cs
+++ b/src/Serilog.Enrichers.ClassName/LoggingExtensions.cs
@@ -1,27 +1,26 @@
 ﻿using Serilog.Configuration;
 using System.Diagnostics;
 
-namespace Serilog.Enrichers.ClassName
+namespace Serilog;
+
+public static class LoggingExtensions
 {
-    public static class LoggingExtensions
-    {        
-        public static LoggerConfiguration WithClassName<T>(this LoggerEnrichmentConfiguration enrich) where T : class 
-        {
-            _ = enrich ?? throw new ArgumentNullException(nameof(enrich));
+    public static LoggerConfiguration WithClassName<T>(this LoggerEnrichmentConfiguration enrich) where T : class
+    {
+        _ = enrich ?? throw new ArgumentNullException(nameof(enrich));
 
-            enrich.WithProperty("SourceContext", typeof(T).FullName);
-            return enrich.With<ClassNameEnricher>();
-        }
+        enrich.WithProperty("SourceContext", typeof(T).FullName);
+        return enrich.With<ClassNameEnricher>();
+    }
 
-        public static LoggerConfiguration WithClassName(this LoggerEnrichmentConfiguration enrich)
-        {
-            _ = enrich ?? throw new ArgumentNullException(nameof(enrich));
+    public static LoggerConfiguration WithClassName(this LoggerEnrichmentConfiguration enrich)
+    {
+        _ = enrich ?? throw new ArgumentNullException(nameof(enrich));
 
-            var stackFrame = new StackTrace().GetFrame(1);
-            var declaringType = stackFrame?.GetMethod()?.DeclaringType;
+        var stackFrame = new StackTrace().GetFrame(1);
+        var declaringType = stackFrame?.GetMethod()?.DeclaringType;
 
-            enrich.WithProperty("SourceContext", declaringType?.FullName ?? "Unknown");
-            return enrich.With<ClassNameEnricher>();
-        }
+        enrich.WithProperty("SourceContext", declaringType?.FullName ?? "Unknown");
+        return enrich.With<ClassNameEnricher>();
     }
 }


### PR DESCRIPTION
- [x] Use serilog namespace to avoid excessive namespace using statements cd33ed2